### PR TITLE
Fix: CompatHelper throwing exception when there is no connection to HA

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent/Functions/CompatHelper.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Functions/CompatHelper.cs
@@ -9,31 +9,57 @@ namespace HASS.Agent.Functions
 {
     internal static class CompatHelper
     {
-        internal static (int, int, int) SplitHAVerion(string haVersion)
+        private static (int, int, int) SplitHAVerion(string haVersion)
         {
             var splitVersion = haVersion.Split('.');
 
-            _ = int.TryParse(splitVersion[0], out int major);
-            _ = int.TryParse(splitVersion[1], out int minor);
+            var major = 0;
+            if (splitVersion.Length > 0)
+            {
+                _ = int.TryParse(splitVersion[0], out major);
+            }
 
-            int patch = 0;
+            var minor = 0;
+            if (splitVersion.Length > 1)
+            {
+                _ = int.TryParse(splitVersion[1], out minor);
+            }
+
+            var patch = 0;
             if (splitVersion.Length > 2)
+            {
                 _ = int.TryParse(splitVersion[2], out patch);
+            }
 
             return (major, minor, patch);
         }
 
+        /// <summary>
+        /// Function checks if the Home Assistant connected to HASS.Agent is greater or equal to <paramref name="haVersion"/>.
+        /// </summary>
+        /// <param name="haVersion"></param>
+        /// <returns>
+        /// True if version is greater or equal from <paramref name="haVersion"/>.
+        /// False if version is lower of there is no connection to Home Assistant instance or it's version cannot be determined.
+        /// </returns>
         internal static bool HassVersionEqualOrOver(string haVersion)
         {
-            if (haVersion == null)
+            if (string.IsNullOrWhiteSpace(haVersion) || string.IsNullOrWhiteSpace(HassApiManager.HaVersion))
+            {
                 return false;
+            }
 
             var (targetMajor, targetMinor, targetPatch) = SplitHAVerion(haVersion);
             var (major, minor, patch) = SplitHAVerion(HassApiManager.HaVersion);
 
+            if(major == 0)
+            {
+                return false;
+            }
+
             return major > targetMajor
                 || major == targetMajor && minor > targetMinor
-                || major == targetMajor && minor == targetMinor && patch > targetPatch;
+                || major == targetMajor && minor == targetMinor && patch >= targetPatch;
         }
     }
 }


### PR DESCRIPTION
This PR:
- fixes issue where exception is thrown if check for HA version is made, whilst there is no actual connection to HA
- adds additional checks to the CompatHelper to make sure that in worst case scenario "false" is returned instead of exception

Cases for the edge case:
- user tries to add sensor/command when HASS.Agent was never fully configured
- user tries to add sensor/command before HASS.Agent makes connection to HA (+-ten-ish seconds after HASS.Agent starts)
- user tries to add sensor/command after connection between HASS.Agent and HA is broken

Should remediate part of the issue reported via https://github.com/amadeo-alex/HASS.Agent/issues/10