### PR TITLE
Fix: Virtual Desktop management availability handling

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -488,6 +488,15 @@ namespace HASS.Agent.Forms.Commands
 						Command.Command = selectedItem.Key;
 					}
 					break;
+
+                case CommandType.SwitchDesktopCommand:
+                    if (!VirtualDesktopManager.Initialized)
+                    {
+                        MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_VirtualDesktop_Unavailable, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        ActiveControl = TbSetting;
+                        return;
+                    }
+                    break;
 			}
 
 			Command.RunAsLowIntegrity = CbRunAsLowIntegrity.CheckState == CheckState.Checked;

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -317,7 +317,7 @@ namespace HASS.Agent.Forms
         /// </summary>
         private void InitializeVirtualDesktopManager()
         {
-            VirtualDesktop.Configure();
+            VirtualDesktopManager.Initialized();
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -317,7 +317,7 @@ namespace HASS.Agent.Forms
         /// </summary>
         private void InitializeVirtualDesktopManager()
         {
-            VirtualDesktopManager.Initialized();
+            VirtualDesktopManager.Initialize();
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Sensors/SensorsMod.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Sensors/SensorsMod.cs
@@ -12,6 +12,7 @@ using Serilog;
 using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
 using HASS.Agent.Managers.DeviceSensors;
+using HASS.Agent.Managers;
 
 namespace HASS.Agent.Forms.Sensors
 {
@@ -789,7 +790,16 @@ namespace HASS.Agent.Forms.Sensors
 					}
 					Sensor.Query = windowprocess;
 					break;
-			}
+
+                case SensorType.ActiveDesktopSensor:
+                    if (!VirtualDesktopManager.Initialized)
+                    {
+                        MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_VirtualDesktop_Unavailable, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        ActiveControl = TbSetting1;
+                        return;
+                    }
+                    break;
+            }
 
 			// set values
 			Sensor.Type = sensorCard.SensorType;

--- a/src/HASS.Agent.Staging/HASS.Agent/HASS.Agent.csproj
+++ b/src/HASS.Agent.Staging/HASS.Agent/HASS.Agent.csproj
@@ -65,12 +65,12 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Slions.VirtualDesktop" Version="6.2.1" />
     <PackageReference Include="Syncfusion.Core.WinForms" Version="20.3.0.50" />
     <PackageReference Include="Syncfusion.Licensing" Version="20.3.0.50" />
     <PackageReference Include="Syncfusion.Shared.Base" Version="20.3.0.50" />
     <PackageReference Include="Syncfusion.Tools.Windows" Version="20.3.0.50" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-    <PackageReference Include="VirtualDesktop" Version="5.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/Commands/CustomCommands/SwitchDesktopCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/Commands/CustomCommands/SwitchDesktopCommand.cs
@@ -1,92 +1,71 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using HASS.Agent.Managers;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Managers;
 using Serilog;
 using WindowsDesktop;
 
-namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands
+namespace HASS.Agent.Shared.HomeAssistant.Commands.InternalCommands;
+
+/// <summary>
+/// Activates provided Virtual Desktop
+/// </summary>
+public class SwitchDesktopCommand : InternalCommand
 {
-    /// <summary>
-    /// Activates provided Virtual Desktop
-    /// </summary>
-    public class SwitchDesktopCommand : InternalCommand
+    private const string DefaultName = "switchdesktop";
+
+    public SwitchDesktopCommand(string name = DefaultName, string friendlyName = DefaultName, string desktopId = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, desktopId, entityType, id)
     {
-        private const string DefaultName = "switchdesktop";
+        CommandConfig = desktopId;
+        State = "OFF";
+    }
 
-        public SwitchDesktopCommand(string name = DefaultName, string friendlyName = DefaultName, string desktopId = "", CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, desktopId, entityType, id)
+    public override void TurnOn()
+    {
+        State = "ON";
+
+        if (string.IsNullOrWhiteSpace(CommandConfig))
         {
-            CommandConfig = desktopId;
-            State = "OFF";
-        }
-
-        public override void TurnOn()
-        {
-            State = "ON";
-
-            if (string.IsNullOrWhiteSpace(CommandConfig))
-            {
-                Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, it's configured as action-only", Name);
-
-                State = "OFF";
-                return;
-            }
-
-            ActivateVirtualDesktop(CommandConfig);
+            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, it's configured as action-only", Name);
 
             State = "OFF";
+            return;
         }
 
-        public override void TurnOnWithAction(string action)
+        ActivateVirtualDesktop(CommandConfig);
+
+        State = "OFF";
+    }
+
+    public override void TurnOnWithAction(string action)
+    {
+        State = "ON";
+
+        if (string.IsNullOrWhiteSpace(action))
         {
-            State = "ON";
-
-            if (string.IsNullOrWhiteSpace(action))
-            {
-                Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, empty action provided", Name);
-
-                State = "OFF";
-                return;
-            }
-
-            if (!string.IsNullOrWhiteSpace(CommandConfig))
-            {
-                Log.Warning("[SWITCHDESKTOP] [{name}] Command launched by action, command-provided process will be ignored", Name);
-
-                State = "OFF";
-                return;
-            }
-
-            ActivateVirtualDesktop(action);
+            Log.Warning("[SWITCHDESKTOP] [{name}] Unable to launch command, empty action provided", Name);
 
             State = "OFF";
+            return;
         }
 
-        private void ActivateVirtualDesktop(string virtualDesktopId)
+        if (!string.IsNullOrWhiteSpace(CommandConfig))
         {
-            var targetDesktopGuid = Guid.Empty;
-            var parsed = Guid.TryParse(virtualDesktopId, out targetDesktopGuid);
-            if (!parsed)
-            {
-                Log.Warning("[SWITCHDESKTOP] [{name}] Unable to parse virtual desktop id: {virtualDesktopId}", Name, virtualDesktopId);
-                return;
-            }
+            Log.Warning("[SWITCHDESKTOP] [{name}] Command launched by action, command-provided process will be ignored", Name);
 
-            var targetDesktop = VirtualDesktop.GetDesktops().FirstOrDefault(d => d.Id == targetDesktopGuid);
-            if (targetDesktop == null)
-            {
-                Log.Warning("[SWITCHDESKTOP] [{name}] Unable to find virtual desktop with id: {virtualDesktopId}", Name, virtualDesktopId);
-                return;
-            }
-
-            if (VirtualDesktop.Current == targetDesktop)
-            {
-                Log.Information("[SWITCHDESKTOP] [{name}] Target virtual desktop '{virtualDesktopId}' is already active", Name, virtualDesktopId);
-                return;
-            }
-
-            targetDesktop.Switch();
+            State = "OFF";
+            return;
         }
+
+        ActivateVirtualDesktop(action);
+
+        State = "OFF";
+    }
+
+    private void ActivateVirtualDesktop(string virtualDesktopId)
+    {
+        VirtualDesktopManager.ActivateDesktop(virtualDesktopId);
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/Sensors/GeneralSensors/SingleValue/ActiveDesktopSensor.cs
@@ -23,6 +23,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         private const string _defaultName = "activedesktop";
 
         private string _desktopId = string.Empty;
+        private string _desktopName = string.Empty;
         private string _attributes = string.Empty;
 
         public ActiveDesktopSensor(int? updateInterval = null, string name = _defaultName, string friendlyName = _defaultName, string id = default) : base(name ?? _defaultName, friendlyName ?? null, updateInterval ?? 15, id)
@@ -59,11 +60,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         public override string GetState()
         {
             var currentDesktop = VirtualDesktopManager.GetCurrentDesktop();
-            _desktopId = currentDesktop.Id.ToString();
+            _desktopId = currentDesktop == null ? string.Empty : currentDesktop.Id.ToString();
+            _desktopName = currentDesktop == null ? string.Empty : currentDesktop.Name;
 
             _attributes = JsonConvert.SerializeObject(new
             {
-                desktopName = currentDesktop.Name,
+                desktopName = _desktopName,
                 availableDesktops = VirtualDesktopManager.GetAllDesktopsInfo()
             }, Formatting.Indented);
 
@@ -71,7 +73,5 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         }
 
         public override string GetAttributes() => _attributes;
-
-
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/Managers/VirtualDesktopManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Managers/VirtualDesktopManager.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Win32;
+using Serilog;
+using WindowsDesktop;
+
+namespace HASS.Agent.Managers;
+
+//Note(Amadeo): due to poor m$ decisions on availability of the Virtual Desktop management APIs, there is no good way to manage Virtual Desktops with publicly available ones.
+//We need to rely on on Community made ones which can stop working with new Windows version due to changes in the COM object name changes.
+//This means it's required to limit the functionality on systems not to expose users to runtime application errors.
+internal static class VirtualDesktopManager
+{
+    public static bool Initialized { get; private set; } = false;
+
+    internal static bool Initialize()
+    {
+        try
+        {
+            VirtualDesktop.Configure();
+            Initialized = true;
+            Log.Information("[VIRTDESKT] Virtual Desktop Manager initialized");
+        }
+        catch
+        {
+            Initialized = false;
+            Log.Error("[VIRTDESKT] Error initializing Virtual Desktop Manager, your Windows version may be unsupported"); //TODO(Amadeo): add link to documentation explaining the issue.
+        }
+
+        return Initialized;
+    }
+
+    internal static void ActivateDesktop(string virtualDesktopId)
+    {
+        if(!Initialized)
+        {
+            Log.Warning("[VIRTDESKT] Cannot activate virtual desktop, manager not initialized");
+        }
+
+        Guid targetDesktopGuid;
+        var parsed = Guid.TryParse(virtualDesktopId, out targetDesktopGuid);
+        if (!parsed)
+        {
+            Log.Warning("[VIRTDESKT] Unable to parse virtual desktop id: {virtualDesktopId}", virtualDesktopId);
+            return;
+        }
+
+        ActivateDesktop(targetDesktopGuid);
+    }
+
+    internal static void ActivateDesktop(Guid virtualDesktopGuid)
+    {
+        if (!Initialized)
+        {
+            Log.Warning("[VIRTDESKT] Cannot activate virtual desktop, manager not initialized");
+        }
+
+        var targetDesktop = VirtualDesktop.GetDesktops().FirstOrDefault(d => d.Id == virtualDesktopGuid);
+        if (targetDesktop == null)
+        {
+            Log.Warning("[VIRTDESKT] Unable to find virtual desktop with id: {virtualDesktopId}", virtualDesktopGuid.ToString());
+            return;
+        }
+
+        if (VirtualDesktop.Current == targetDesktop)
+        {
+            Log.Information("[VIRTDESKT] Target virtual desktop '{virtualDesktopId}' is already active", virtualDesktopGuid.ToString());
+            return;
+        }
+
+        targetDesktop.Switch();
+    }
+
+    internal static VirtualDesktop GetCurrentDesktop()
+    {
+        if (!Initialized)
+        {
+            Log.Warning("[VIRTDESKT] Cannot get current desktop, manager not initialized");
+            
+            return null;
+        }
+
+        return VirtualDesktop.Current;
+    }
+
+    private static string GetDesktopNameFromRegistry(string id)
+    {
+        var registryPath = $"HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops\\Desktops\\{{{id}}}";
+        return (Registry.GetValue(registryPath, "Name", string.Empty) as string) ?? string.Empty;
+    }
+
+    internal static Dictionary<string, string> GetAllDesktopsInfo()
+    {
+        var desktops = new Dictionary<string, string>();
+        foreach (var desktop in VirtualDesktop.GetDesktops())
+        {
+            var id = desktop.Id.ToString();
+            desktops[id] = string.IsNullOrWhiteSpace(desktop.Name) ? GetDesktopNameFromRegistry(id) : desktop.Name;
+        }
+
+        return desktops;
+    }
+}

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.Designer.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.Designer.cs
@@ -623,7 +623,7 @@ namespace HASS.Agent.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Activates provided Virtual Desktop..
+        ///   Looks up a localized string similar to Activates provided Virtual Desktop. Desktop ID can be retrieved from the &quot;ActiveDesktop&quot; sensor..
         /// </summary>
         internal static string CommandsManager_SwitchDesktopCommandDescription {
             get {
@@ -786,6 +786,16 @@ namespace HASS.Agent.Resources.Localization {
         internal static string CommandsMod_BtnStore_MessageBox9 {
             get {
                 return ResourceManager.GetString("CommandsMod_BtnStore_MessageBox9", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Virtual Desktop management is unavailable on your machine.
+        ///Usually this is due to the virtual desktop management library not being updated to support your version of Windows..
+        /// </summary>
+        internal static string CommandsMod_BtnStore_VirtualDesktop_Unavailable {
+            get {
+                return ResourceManager.GetString("CommandsMod_BtnStore_VirtualDesktop_Unavailable", resourceCulture);
             }
         }
         

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -3444,4 +3444,8 @@ Die Verfügbarkeit des Sensors ist geräteabhängig, in manchen Fällen sind kei
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Aktiviert den bereitgestellten virtuellen Desktop. Die Desktop-ID kann vom „ActiveDesktop“-Sensor abgerufen werden.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Die Verwaltung virtueller Desktops ist auf Ihrem Computer nicht verfügbar.
+Normalerweise liegt dies daran, dass die virtuelle Desktop-Verwaltungsbibliothek nicht aktualisiert wird, um Ihre Windows-Version zu unterstützen.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -3320,4 +3320,8 @@ If no "mute" is provided, HASS.Agent will unmute the provided application.</valu
   <data name="CommandsMod_BtnStore_InvalidJson" xml:space="preserve">
     <value>Please enter a valid JSON string!</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Virtual Desktop management is unavailable on your machine.
+Usually this is due to the virtual desktop management library not being updated to support your version of Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -3319,4 +3319,8 @@ La disponibilidad del sensor depende del dispositivo; en algunos casos, no habr�
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Activa el escritorio virtual proporcionado. Desktop ID se puede recuperar del sensor "ActiveDesktop".</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>La administración de escritorio virtual no está disponible en su máquina.
+Por lo general, esto se debe a que la biblioteca de administración de escritorio virtual no se actualiza para admitir su versión de Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -3352,4 +3352,8 @@ La disponibilité du capteur dépend de l'appareil ; dans certains cas, aucun ca
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Active le bureau virtuel fourni. L'ID du bureau peut être récupéré à partir du capteur "ActiveDesktop".</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>La gestion des bureaux virtuels n'est pas disponible sur votre machine.
+Cela est généralement dû au fait que la bibliothèque de gestion des bureaux virtuels n'est pas mise à jour pour prendre en charge votre version de Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -3340,4 +3340,8 @@ Beschikbaarheid van de sensor is afhankelijk van het apparaat, in sommige gevall
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Activeert het meegeleverde virtuele bureaublad. Desktop-ID kan worden opgehaald van de "ActiveDesktop"-sensor.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Beheer van virtuele desktops is niet beschikbaar op uw machine.
+Meestal komt dit doordat de virtuele desktopbeheerbibliotheek niet wordt bijgewerkt om uw versie van Windows te ondersteunen.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -3429,4 +3429,8 @@ Dostępność czujnika zależy od urządzenia, w niektórych przypadkach czujnik
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Aktywuje podany pulpit wirtualny. Identyfikator pulpitu można pobrać z czujnika „ActiveDesktop”.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Zarządzanie pulpitem wirtualnym jest niedostępne na Twoim komputerze.
+Zwykle jest to spowodowane brakiem aktualizacji biblioteki zarządzania pulpitem wirtualnym do obsługi Twojej wersji systemu Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -3366,4 +3366,8 @@ A disponibilidade do sensor depende do dispositivo; em alguns casos, nenhum sens
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Ativa a área de trabalho virtual fornecida. A ID da área de trabalho pode ser recuperada do sensor "ActiveDesktop".</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>O gerenciamento da área de trabalho virtual não está disponível em sua máquina.
+Geralmente, isso ocorre porque a biblioteca de gerenciamento de desktop virtual não está sendo atualizada para oferecer suporte à sua versão do Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.resx
@@ -3332,4 +3332,8 @@ to match Home Assistant 2023.8 requirements</value>
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Activates provided Virtual Desktop. Desktop ID can be retrieved from the "ActiveDesktop" sensor.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Virtual Desktop management is unavailable on your machine.
+Usually this is due to the virtual desktop management library not being updated to support your version of Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -3388,4 +3388,8 @@ Home Assistant.
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Активирует предоставленный виртуальный рабочий стол. Идентификатор рабочего стола можно получить с датчика ActiveDesktop.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Управление виртуальным рабочим столом на вашем компьютере недоступно.
+Обычно это происходит из-за того, что библиотека управления виртуальными рабочими столами не обновляется для поддержки вашей версии Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -3468,4 +3468,8 @@ Razpoložljivost senzorja je odvisna od naprave, v nekaterih primerih senzorji n
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Aktivira ponujeno navidezno namizje. ID namizja je mogoče pridobiti iz senzorja "ActiveDesktop".</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Upravljanje navideznega namizja na vašem računalniku ni na voljo.
+Običajno je to posledica tega, da knjižnica za upravljanje navideznega namizja ni posodobljena za podporo vaše različice sistema Windows.</value>
+  </data>
 </root>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -2931,4 +2931,8 @@ Sensörün kullanılabilirliği cihaza bağlıdır; bazı durumlarda sensör bul
   <data name="CommandsManager_SwitchDesktopCommandDescription" xml:space="preserve">
     <value>Sağlanan Sanal Masaüstünü etkinleştirir. Masaüstü Kimliği "ActiveDesktop" sensöründen alınabilir.</value>
   </data>
+  <data name="CommandsMod_BtnStore_VirtualDesktop_Unavailable" xml:space="preserve">
+    <value>Makinenizde Sanal Masaüstü yönetimi mevcut değil.
+Bunun nedeni genellikle sanal masaüstü yönetim kitaplığının Windows sürümünüzü destekleyecek şekilde güncellenmemesidir.</value>
+  </data>
 </root>


### PR DESCRIPTION
This PR:
- changes VirtualDesktop library to https://github.com/Slion/VirtualDesktop (maintained fork of the original one)
- adds backend checks for library initialisation - library is wrapped into a manager class 
- adds checks for user trying to add virtual desktop sensor/command which prevent them to be added
- adds checks for the specific functions used by the virtual desktop sensor/command in case of manual configuration in the json files

Should remediate second issue reported in https://github.com/amadeo-alex/HASS.Agent/issues/10

Error presented to the user when trying to configure sensor/command in unsupported setup:
![GQQuq8](https://github.com/amadeo-alex/HASS.Agent/assets/68441479/31c1f0ab-cc65-4219-b566-14999745d2e5)

Error printed to the logs when unsupported setup is detected:
![j6a25r](https://github.com/amadeo-alex/HASS.Agent/assets/68441479/905abe13-2a48-4f8c-80f6-400ecdbd0119)