### PR TITLE
Fix: hardware sensors crashing application

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Satellite.Service/Worker.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Satellite.Service/Worker.cs
@@ -6,6 +6,7 @@ using HASS.Agent.Satellite.Service.RPC;
 using HASS.Agent.Satellite.Service.Sensors;
 using HASS.Agent.Satellite.Service.Settings;
 using Serilog;
+using HASS.Agent.Shared.Managers;
 
 namespace HASS.Agent.Satellite.Service
 {
@@ -38,6 +39,8 @@ namespace HASS.Agent.Satellite.Service
             try
             {
                 _log.LogInformation("[WORKER] Startup completed, commencing execution ..");
+
+                HardwareManager.Initialize();
 
                 // load stored settings (if any)
                 var launched = await SettingsManager.LoadAsync();
@@ -96,6 +99,8 @@ namespace HASS.Agent.Satellite.Service
             }
             finally
             {
+                HardwareManager.Shutdown();
+
                 // stop the application
                 _hostApplicationLifetime.StopApplication();
 

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -18,7 +18,8 @@ public class GpuLoadSensor : AbstractSingleValueSensor
 	{
 		_gpu = HardwareManager.Hardware.FirstOrDefault(
 			h => h.HardwareType == HardwareType.GpuAmd ||
-			h.HardwareType == HardwareType.GpuNvidia
+			h.HardwareType == HardwareType.GpuNvidia ||
+            h.HardwareType == HardwareType.GpuIntel
 		);
 	}
 

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -1,71 +1,62 @@
 ﻿using System.Globalization;
 using System.Linq;
+using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using LibreHardwareMonitor.Hardware;
 
-namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
+namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue;
+
+/// <summary>
+/// Sensor indicating the current GPU load
+/// </summary>
+public class GpuLoadSensor : AbstractSingleValueSensor
 {
-    /// <summary>
-    /// Sensor indicating the current GPU load
-    /// </summary>
-    public class GpuLoadSensor : AbstractSingleValueSensor
-    {
-        private const string DefaultName = "gpuload";
-        private readonly IHardware _gpu;
+	private const string DefaultName = "gpuload";
+	private readonly IHardware _gpu;
 
-        public GpuLoadSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
-        {
-            var computer = new Computer
-            {
-                IsCpuEnabled = false,
-                IsGpuEnabled = true,
-                IsMemoryEnabled = false,
-                IsMotherboardEnabled = false,
-                IsControllerEnabled = false,
-                IsNetworkEnabled = false,
-                IsStorageEnabled = false,
-            };
+	public GpuLoadSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
+	{
+		_gpu = HardwareManager.Hardware.FirstOrDefault(
+			h => h.HardwareType == HardwareType.GpuAmd ||
+			h.HardwareType == HardwareType.GpuNvidia
+		);
+	}
 
-            computer.Open();
-            _gpu = computer.Hardware.FirstOrDefault(h => h.HardwareType == HardwareType.GpuAmd || h.HardwareType == HardwareType.GpuNvidia);
+	public override DiscoveryConfigModel GetAutoDiscoveryConfig()
+	{
+		if (Variables.MqttManager == null)
+			return null;
 
-            computer.Close();
-        }
+		var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
+		if (deviceConfig == null)
+			return null;
 
-        public override DiscoveryConfigModel GetAutoDiscoveryConfig()
-        {
-            if (Variables.MqttManager == null) return null;
+		return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
+		{
+			Name = Name,
+			FriendlyName = FriendlyName,
+			Unique_id = Id,
+			Device = deviceConfig,
+			State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
+			Unit_of_measurement = "%",
+			Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
+		});
+	}
 
-            var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
-            if (deviceConfig == null) return null;
+	public override string GetState()
+	{
+		if (_gpu == null)
+			return null;
 
-            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
-            {
-                Name = Name,
-                FriendlyName = FriendlyName,
-                Unique_id = Id,
-                Device = deviceConfig,
-                State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
-                Unit_of_measurement = "%",
-                Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/availability"
-            });
-        }
+		_gpu.Update();
 
-        public override string GetState()
-        {
-            if (_gpu == null)
-                return null;
+		var sensor = _gpu.Sensors.FirstOrDefault(s => s.SensorType == SensorType.Load);
 
-            _gpu.Update();
+		if (sensor?.Value == null)
+			return null;
 
-            var sensor = _gpu.Sensors.FirstOrDefault(s => s.SensorType == SensorType.Load);
+		return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
+	}
 
-            if (sensor?.Value == null)
-                return null;
-
-            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
-        }
-
-        public override string GetAttributes() => string.Empty;
-    }
+	public override string GetAttributes() => string.Empty;
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Linq;
+using HASS.Agent.Shared.Managers;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using LibreHardwareMonitor.Hardware;
 
@@ -15,22 +16,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public GpuTemperatureSensor(int? updateInterval = null, string name = DefaultName, string friendlyName = DefaultName, string id = default) : base(name ?? DefaultName, friendlyName ?? null, updateInterval ?? 30, id)
         {
-            var computer = new Computer
-            {
-                IsCpuEnabled = false,
-                IsGpuEnabled = true,
-                IsMemoryEnabled = false,
-                IsMotherboardEnabled = false,
-                IsControllerEnabled = false,
-                IsNetworkEnabled = false,
-                IsStorageEnabled = false,
-            };
-
-            computer.Open();
-            _gpu = computer.Hardware.FirstOrDefault(h => h.HardwareType == HardwareType.GpuAmd || h.HardwareType == HardwareType.GpuNvidia);
-
-            computer.Close();
-        }
+			_gpu = HardwareManager.Hardware.FirstOrDefault(
+				h => h.HardwareType == HardwareType.GpuAmd ||
+				h.HardwareType == HardwareType.GpuNvidia
+			);
+		}
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -18,7 +18,8 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
         {
 			_gpu = HardwareManager.Hardware.FirstOrDefault(
 				h => h.HardwareType == HardwareType.GpuAmd ||
-				h.HardwareType == HardwareType.GpuNvidia
+				h.HardwareType == HardwareType.GpuNvidia ||
+                h.HardwareType == HardwareType.GpuIntel
 			);
 		}
 

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/HardwareManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/HardwareManager.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LibreHardwareMonitor.Hardware;
+
+namespace HASS.Agent.Shared.Managers;
+public static class HardwareManager
+{
+	private static Computer s_computer;
+	public static void Initialize()
+	{
+		//Note(Amadeo): for "performance" reasons only GPU is selected below, enable additional ones if required by new sensors/commands
+		s_computer = new Computer()
+		{
+			IsCpuEnabled = false,
+			IsGpuEnabled = true,
+			IsMemoryEnabled = false,
+			IsMotherboardEnabled = false,
+			IsControllerEnabled = false,
+			IsNetworkEnabled = false,
+			IsStorageEnabled = false,
+		};
+
+		s_computer.Open();
+	}
+
+	public static IList<IHardware> Hardware => s_computer.Hardware;
+
+	public static void Shutdown() => s_computer?.Close();
+}

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -19,6 +19,7 @@ using HASS.Agent.Shared;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Extensions;
 using HASS.Agent.Shared.Functions;
+using HASS.Agent.Shared.Managers;
 using Serilog;
 using Syncfusion.Windows.Forms;
 using WindowsDesktop;
@@ -86,11 +87,11 @@ namespace HASS.Agent.Forms
                 CheckDpiScalingFactor();
 
                 await RadioManager.Initialize();
-
                 await InternalDeviceSensorsManager.Initialize();
+				InitializeHardwareManager();
 
-                // load entities
-                var loaded = await SettingsManager.LoadEntitiesAsync();
+				// load entities
+				var loaded = await SettingsManager.LoadEntitiesAsync();
                 if (!loaded)
                 {
                     MessageBoxAdv.Show(this, Languages.Main_Load_MessageBox1, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
@@ -106,23 +107,16 @@ namespace HASS.Agent.Forms
                 // initialize hass.agent's shared library
                 AgentSharedBase.Initialize(Variables.AppSettings.DeviceName, Variables.MqttManager, Variables.AppSettings.CustomExecutorBinary);
 
-                // process onboarding
                 ProcessOnboarding();
 
                 // if we're shutting down, no point continuing
                 if (Variables.ShuttingDown)
                     return;
 
-                // prepare the tray icon config
                 ProcessTrayIcon();
-
-                // initialize hotkeys
                 InitializeHotkeys();
-
-                // initialize Virtual Desktop library
                 InitializeVirtualDesktopManager();
 
-                // initialize managers
                 var initTask = Task.Run(async () =>
                 {
                     _ = Task.Run(ApiManager.Initialize);
@@ -168,6 +162,7 @@ namespace HASS.Agent.Forms
 
         private void OnProcessExit(object sender, EventArgs e)
         {
+            HardwareManager.Shutdown();
             NotificationManager.Exit();
         }
 
@@ -321,6 +316,14 @@ namespace HASS.Agent.Forms
         private void InitializeVirtualDesktopManager()
         {
             VirtualDesktopManager.Initialize();
+        }
+
+        /// <summary>
+        /// Initialized the Hardware Manager
+        /// </summary>
+        private void InitializeHardwareManager()
+        {
+            HardwareManager.Initialize();
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -86,9 +86,11 @@ namespace HASS.Agent.Forms
                 // check for dpi scaling
                 CheckDpiScalingFactor();
 
+                // core components initialization - required for loading the entities
                 await RadioManager.Initialize();
                 await InternalDeviceSensorsManager.Initialize();
 				InitializeHardwareManager();
+				InitializeVirtualDesktopManager();
 
 				// load entities
 				var loaded = await SettingsManager.LoadEntitiesAsync();
@@ -115,7 +117,6 @@ namespace HASS.Agent.Forms
 
                 ProcessTrayIcon();
                 InitializeHotkeys();
-                InitializeVirtualDesktopManager();
 
                 var initTask = Task.Run(async () =>
                 {


### PR DESCRIPTION
This PR:
- fixes issue where hardware sensors (GPU load and temperature) would silently crash the application due to the memory violation.
- adds additional check for Intel GPU (AMD->NVIDIA->Intel)

Should remediate https://github.com/amadeo-alex/HASS.Agent/issues/14

The root cause of the issue was "closing of computer" class from LibreHardwareMonitor after obtaining the GPU object.
This has been remediated by introducing a HardwareManager class.
